### PR TITLE
Support multiple headers at the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next
 
+* [#6](https://github.com/TinkerDev/grape-swagger-rails/pull/6): Fix: support multiple predefined headers - [@Tyr0](https://github.com/tyr0).
 * Your contribution here.
 
 ### 0.1.0 (February 5, 2015)

--- a/app/views/grape_swagger_rails/application/index.html.erb
+++ b/app/views/grape_swagger_rails/application/index.html.erb
@@ -46,8 +46,8 @@
       }
     });
 
-    <% GrapeSwaggerRails.options.headers.each_pair do |key, value| %>
-      <%=raw "window.authorizations.add('key', new ApiKeyAuthorization('#{CGI.escapeHTML(key)}', '#{CGI.escapeHTML(value)}', 'header'));" %>
+    <% GrapeSwaggerRails.options.headers.each_with_index do |(key, value), index| %>
+      <%=raw "window.authorizations.add('header_#{index}', new ApiKeyAuthorization('#{CGI.escapeHTML(key)}', '#{CGI.escapeHTML(value)}', 'header'));" %>
     <% end %>
 
     window.swaggerUi.load();

--- a/spec/features/swagger_spec.rb
+++ b/spec/features/swagger_spec.rb
@@ -19,14 +19,24 @@ describe 'Swagger' do
     context "#headers" do
       before do
         GrapeSwaggerRails.options.headers['X-Test-Header'] = 'Test Value'
+        GrapeSwaggerRails.options.headers['X-Another-Header'] = 'Another Value'
         visit '/swagger'
       end
       it 'adds headers' do
         find('#endpointListTogger_headers', visible: true).click
-        find('a[href="#!/headers/GET_api_headers_format"]', visible: true).click
+        first('a[href="#!/headers/GET_api_headers_format"]', visible: true).click
         click_button 'Try it out!'
         expect(page).to have_css "span.attribute", text: 'X-Test-Header'
         expect(page).to have_css "span.string", text: 'Test Value'
+      end
+      it 'supports multiple headers' do
+        find('#endpointListTogger_headers', visible: true).click
+        first('a[href="#!/headers/GET_api_headers_format"]', visible: true).click
+        click_button 'Try it out!'
+        expect(page).to have_css "span.attribute", text: 'X-Test-Header'
+        expect(page).to have_css "span.string", text: 'Test Value'
+        expect(page).to have_css "span.attribute", text: 'X-Another-Header'
+        expect(page).to have_css "span.string", text: 'Another Value'
       end
     end
     context "#api_auth:basic" do


### PR DESCRIPTION
Swagger supports multiple headers but requires that each one uses a unique name. The existing approach overwrote the previous header definition. This also caused issues when changing the value of `#input_apiKey` as it stores the api key with the same name as all defined headers, leading to complete header loss on api key addition. This fix ensures each header is given a unique name.

For more information see: https://github.com/swagger-api/swagger-ui#header-parameters